### PR TITLE
Convert maxspeed in mph to km/h

### DIFF
--- a/app/lts.py
+++ b/app/lts.py
@@ -116,6 +116,10 @@ class LTSAnalyzer:
                 maxspeed = way.tags.get("maxspeed")
                 if "maxspeed" == "national":
                     return 40
+                if 'mph' in maxspeed:
+                    i = maxspeed.find('mph')
+                    # convert mph to approximate km/h
+                    return int(maxspeed[:i]) * 1.6 
                 return int(maxspeed)
             if way.tags.get("highway") == "motorway":
                 return 100


### PR DESCRIPTION
Approximately converts maxspeed values specified in miles per hour to km/h.

Note: this was causing the program to break when OSM data from the USA is put in there because the `get_maxspeed()` function would raise a `ValueError` when `maxspeed` tag had value in miles per hour like "30 mph" and that terminated the problem. 